### PR TITLE
Injecting custom scripts into render process

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ or
       -t TIMEOUT, --timeout=TIMEOUT
                             Try hard to inject for the time specified [default:
                             none]
+      -r RENDER_SCRIPTS, --render-script=RENDER_SCRIPTS
+                            Add a script to be injected into each window (render
+                            thread)
 
 # Showcase
 


### PR DESCRIPTION
Passing the ``-r file`` parameter allows to pass a list of scripts to be injected into the **render** thread. It does not follow imports, just evaluate the text

``python -m electron_inject -r ./test.js -r ~/test2.js -r /usr/bin/test3.js - /opt/electron-api-demos/Electron\ API\ Demos ``

I ended up making this while searching for a solution to inject in the main thread