### PR TITLE
Bug fixes & bookkeeping

### DIFF
--- a/electron_inject/__init__.py
+++ b/electron_inject/__init__.py
@@ -93,7 +93,7 @@ class ElectronRemoteDebugger(object):
         ret = json.loads(w['ws'].sendrcv(json.dumps(data)))
         if "result" not in ret:
             return ret
-        if ret['result']['wasThrown']:
+        if ret['result'].get('wasThrown'):
             raise Exception(ret['result']['result'])
         return ret['result']
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     #python setup.py register -r https://testpypi.python.org/pypi
     long_description=read("README.md"),
     long_description_content_type='text/markdown',
-    install_requires=['websocket','requests'],
+    install_requires=['websocket-client','requests'],
     package_data = {
                     'electron_inject': ['electron_inject'],
                     },

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
         return "Not available"
 setup(
     name="electron-inject",
-    version="0.5",
+    version="0.6",
     packages=["electron_inject"],
     author="tintinweb",
     author_email="tintinweb@oststrom.com",
@@ -20,7 +20,7 @@ setup(
     license="GPLv3",
     keywords=["electron", "inject", "devtools", "developer tools"],
     url="https://github.com/tintinweb/electron-inject/",
-    download_url="https://github.com/tintinweb/electron-inject/tarball/v0.5",
+    download_url="https://github.com/tintinweb/electron-inject/tarball/v0.6",
     #python setup.py register -r https://testpypi.python.org/pypi
     long_description=read("README.md"),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Thanks for your work on this tool! It's been very useful to me. I've just made a few minor changes to address these issues:
* The current version on PyPI is not usable because it (incorrectly, I believe) depends on `websocket` instead of `websocket-client`. 
* The version number in `setup.py` was still 0.5.
* `ElectronRemoteDebugger.eval` raised an uncaught KeyError on some JSON responses.