### PR TITLE
add --remote-allow-origins to allow websocket connection

### DIFF
--- a/electron_inject/__init__.py
+++ b/electron_inject/__init__.py
@@ -109,7 +109,7 @@ class ElectronRemoteDebugger(object):
             port = sock.getsockname()[1]
             sock.close()
 
-        cmd = "%s %s" % (path, "--remote-debugging-port=%d" % port)
+        cmd = "%s %s" % (path, "--remote-allow-origins=http://localhost:%d --remote-debugging-port=%d" % (port, port))
         print (cmd)
         p = subprocess.Popen(cmd, shell=True)
         time.sleep(0.5)


### PR DESCRIPTION
Hi!

Thanks for creating this!

I was having an issue where the debugger websocket connection was blocked by the electron runtime and needed to add `--remote-allow-origins` in order to allow the debugger to connect.